### PR TITLE
Content-type handling in DELETE and PUT methods

### DIFF
--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -12,6 +12,7 @@ import type {
   FetcherConfig,
   FetcherInstance,
   Logger,
+  HeadersObject,
 } from './types/request-handler';
 import type {
   BodyPayload,
@@ -172,26 +173,18 @@ export function createRequestHandler(
    * @param {any} [body] - Optional request body to determine if Content-Type is needed.
    */
   const setContentTypeIfNeeded = (
-    headers: HeadersInit,
+    headers: HeadersObject,
     method: string,
     body?: any,
   ) => {
     // For PUT and DELETE methods, do not set Content-Type if no body is provided.
-    if (!body) {
-      if (['PUT', 'DELETE'].includes(method)) {
-        return;
-      }
+    if (['PUT', 'DELETE'].includes(method) && !body) {
+      return;
     }
 
     // Automatically set Content-Type to 'application/json;charset=utf-8' if not already present.
-    if (headers instanceof Headers) {
-      if (!headers.has(CONTENT_TYPE)) {
-        headers.set(CONTENT_TYPE, APPLICATION_JSON + ';charset=utf-8');
-      }
-    } else if (headers && !headers[CONTENT_TYPE]) {
-      if (!headers[CONTENT_TYPE]) {
-        headers[CONTENT_TYPE] = APPLICATION_JSON + ';charset=utf-8';
-      }
+    if (headers && !headers[CONTENT_TYPE]) {
+      headers[CONTENT_TYPE] = APPLICATION_JSON + ';charset=utf-8';
     }
   };
 
@@ -232,7 +225,7 @@ export function createRequestHandler(
       body = explicitBodyData;
     }
 
-    const headers = getConfig<HeadersInit>(requestConfig, 'headers');
+    const headers = getConfig<HeadersObject>(requestConfig, 'headers');
 
     // Add or remove Content-Type depending on the conditions
     setContentTypeIfNeeded(headers, method, body);

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -177,8 +177,10 @@ export function createRequestHandler(
     body?: any,
   ) => {
     // For PUT and DELETE methods, do not set Content-Type if no body is provided.
-    if (['PUT', 'DELETE'].includes(method) && !body) {
-      return;
+    if (!body) {
+      if (['PUT', 'DELETE'].includes(method)) {
+        return;
+      }
     }
 
     // Automatically set Content-Type to 'application/json;charset=utf-8' if not already present.
@@ -186,7 +188,7 @@ export function createRequestHandler(
       if (!headers.has(CONTENT_TYPE)) {
         headers.set(CONTENT_TYPE, APPLICATION_JSON + ';charset=utf-8');
       }
-    } else if (typeof headers === 'object' && !Array.isArray(headers)) {
+    } else if (headers && !headers[CONTENT_TYPE]) {
       if (!headers[CONTENT_TYPE]) {
         headers[CONTENT_TYPE] = APPLICATION_JSON + ';charset=utf-8';
       }

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -173,7 +173,7 @@ export function createRequestHandler(
    * @param {any} [body] - Optional request body to determine if Content-Type is needed.
    */
   const setContentTypeIfNeeded = (
-    headers: HeadersObject,
+    headers: HeadersInit,
     method: string,
     body?: any,
   ) => {
@@ -183,7 +183,15 @@ export function createRequestHandler(
     }
 
     // Automatically set Content-Type to 'application/json;charset=utf-8' if not already present.
-    if (headers && !headers[CONTENT_TYPE]) {
+    if (headers instanceof Headers) {
+      if (!headers.has(CONTENT_TYPE)) {
+        headers.set(CONTENT_TYPE, APPLICATION_JSON + ';charset=utf-8');
+      }
+    } else if (
+      typeof headers === 'object' &&
+      !Array.isArray(headers) &&
+      !headers[CONTENT_TYPE]
+    ) {
       headers[CONTENT_TYPE] = APPLICATION_JSON + ';charset=utf-8';
     }
   };

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -277,6 +277,7 @@ export function createRequestHandler(
       headers,
     };
   };
+
   /**
    * Process global Request Error
    *

--- a/test/request-handler.spec.ts
+++ b/test/request-handler.spec.ts
@@ -10,7 +10,6 @@ import type {
 import { fetchf } from '../src';
 import { ABORT_ERROR } from '../src/constants';
 import { ResponseErr } from '../src/response-error';
-import { APPLICATION_JSON } from '../src/constants';
 
 jest.mock('../src/utils', () => {
   const originalModule = jest.requireActual('../src/utils');
@@ -69,7 +68,9 @@ describe('Request Handler', () => {
     };
 
     beforeAll(() => {
-      requestHandler = createRequestHandler({});
+      requestHandler = createRequestHandler({
+        headers,
+      });
     });
 
     it('should not differ when the same request is made', () => {
@@ -268,6 +269,106 @@ describe('Request Handler', () => {
         method: 'GET',
         params: { foo: 'bar' },
       });
+    });
+  });
+
+  describe('Request Handler - Content-Type Handling', () => {
+    let requestHandler: RequestHandlerReturnType;
+
+    beforeEach(() => {
+      requestHandler = createRequestHandler({});
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should remove Content-Type for DELETE method if no body is provided', () => {
+      const result = requestHandler.buildConfig(apiUrl, {
+        method: 'DELETE',
+      });
+
+      expect(result.headers).not.toHaveProperty('Content-Type');
+    });
+
+    it('should remove Content-Type for PUT method if no body is provided', () => {
+      const result = requestHandler.buildConfig(apiUrl, {
+        method: 'PUT',
+      });
+
+      expect(result.headers).not.toHaveProperty('Content-Type');
+    });
+
+    it('should keep Content-Type for DELETE method if body is provided', () => {
+      const result = requestHandler.buildConfig(apiUrl, {
+        method: 'DELETE',
+        body: { foo: 'bar' },
+      });
+
+      expect(result.headers).toHaveProperty(
+        'Content-Type',
+        'application/json;charset=utf-8',
+      );
+    });
+
+    it('should keep Content-Type for PUT method if body is provided', () => {
+      const result = requestHandler.buildConfig(apiUrl, {
+        method: 'PUT',
+        data: { foo: 'bar' },
+      });
+
+      expect(result.headers).toHaveProperty(
+        'Content-Type',
+        'application/json;charset=utf-8',
+      );
+    });
+
+    it('should not remove Content-Type for other methods', () => {
+      const postResult = requestHandler.buildConfig(apiUrl, {
+        method: 'POST',
+      });
+
+      expect(postResult.headers).toHaveProperty(
+        'Content-Type',
+        'application/json;charset=utf-8',
+      );
+
+      const getResult = requestHandler.buildConfig(apiUrl, {
+        method: 'GET',
+      });
+
+      expect(getResult.headers).toHaveProperty(
+        'Content-Type',
+        'application/json;charset=utf-8',
+      );
+    });
+
+    it('should keep custom Content-Type for DELETE method', () => {
+      const result = requestHandler.buildConfig(apiUrl, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      expect(result.headers).toHaveProperty(
+        'Content-Type',
+        'application/x-www-form-urlencoded',
+      );
+    });
+
+    it('should keep custom Content-Type for PUT method', () => {
+      const result = requestHandler.buildConfig(apiUrl, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      expect(result.headers).toHaveProperty(
+        'Content-Type',
+        'application/x-www-form-urlencoded',
+      );
     });
   });
 
@@ -1211,111 +1312,6 @@ describe('Request Handler', () => {
       expect(
         await requestHandler.request(apiUrl, { method: 'head' }),
       ).toMatchObject({ data: null });
-    });
-  });
-
-  describe('Request Handler - Content-Type Handling', () => {
-    let requestHandler: RequestHandlerReturnType;
-
-    const defaultHeader = {
-      'Content-Type': 'application/json;charset=utf-8',
-      Accept: APPLICATION_JSON + ', text/plain, */*',
-      'Accept-Encoding': 'gzip, deflate, br',
-    };
-
-    beforeEach(() => {
-      requestHandler = createRequestHandler({
-        fetcher,
-        headers: defaultHeader,
-      });
-    });
-
-    it('should remove Content-Type for DELETE method if no body is provided', () => {
-      const result = requestHandler.buildConfig(apiUrl, {
-        method: 'DELETE',
-      });
-
-      expect(result.headers).not.toHaveProperty('Content-Type');
-    });
-
-    it('should remove Content-Type for PUT method if no body is provided', () => {
-      const result = requestHandler.buildConfig(apiUrl, {
-        method: 'PUT',
-      });
-
-      expect(result.headers).not.toHaveProperty('Content-Type');
-    });
-
-    it('should keep Content-Type for DELETE method if body is provided', () => {
-      const result = requestHandler.buildConfig(apiUrl, {
-        method: 'DELETE',
-        body: { foo: 'bar' },
-      });
-
-      expect(result.headers).toHaveProperty(
-        'Content-Type',
-        'application/json;charset=utf-8',
-      );
-    });
-
-    it('should keep Content-Type for PUT method if body is provided', () => {
-      const result = requestHandler.buildConfig(apiUrl, {
-        method: 'PUT',
-        data: { foo: 'bar' },
-      });
-
-      expect(result.headers).toHaveProperty(
-        'Content-Type',
-        'application/json;charset=utf-8',
-      );
-    });
-
-    it('should not remove Content-Type for other methods', () => {
-      const postResult = requestHandler.buildConfig(apiUrl, {
-        method: 'POST',
-      });
-
-      expect(postResult.headers).toHaveProperty(
-        'Content-Type',
-        'application/json;charset=utf-8',
-      );
-
-      const getResult = requestHandler.buildConfig(apiUrl, {
-        method: 'GET',
-      });
-
-      expect(getResult.headers).toHaveProperty(
-        'Content-Type',
-        'application/json;charset=utf-8',
-      );
-    });
-
-    it('should keep custom Content-Type for DELETE method', () => {
-      const result = requestHandler.buildConfig(apiUrl, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      });
-
-      expect(result.headers).toHaveProperty(
-        'Content-Type',
-        'application/x-www-form-urlencoded',
-      );
-    });
-
-    it('should keep custom Content-Type for PUT method', () => {
-      const result = requestHandler.buildConfig(apiUrl, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      });
-
-      expect(result.headers).toHaveProperty(
-        'Content-Type',
-        'application/x-www-form-urlencoded',
-      );
     });
   });
 });


### PR DESCRIPTION
Features:

- Added Content-Type handling for DELETE and PUT methods.
- First, checked if a body is provided. If no body is provided,
- Then checked if Content-Type is explicitly set in requestConfig. If not explicitly set, remove the Content-Type header.

- Additionally, I added some unit tests 😎

#75 

