### PR TITLE
Update react types path and enable dts generation for react build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       }
     },
     "./react": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.mjs",
       "require": "./dist/react/index.cjs"
     }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -37,7 +37,7 @@ export default defineConfig([
     globalName: 'fetchffReact',
     entry: ['src/react/index.ts'],
     target: 'es2018',
-    dts: false,
+    dts: true,
     format: ['esm', 'cjs'],
     outDir: 'dist/react',
     platform: 'neutral',


### PR DESCRIPTION
This pull request includes updates to the TypeScript configuration and package export paths to improve module resolution and type definitions for the React package.

### TypeScript configuration improvements:
* [`tsup.config.ts`](diffhunk://#diff-8fed899bdbc24789a7bb4973574e624ed6207c6ce572338bc3c3e117672b2a20L40-R40): Enabled the generation of TypeScript declaration files (`dts: true`) to ensure type definitions are included in the build output.

### Package export path updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28): Updated the `types` field for the `./react` export to point to `./dist/react/index.d.ts`, aligning it with the new directory structure.