### PR TITLE
Enhance refetch functionality with Request Config

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -17,6 +17,7 @@ import type {
   RequestConfig,
 } from '..';
 import type { UseFetcherResult } from '../types/react-hooks';
+import { RefetchFunction } from '../types/react-hooks';
 
 import {
   decrementRef,
@@ -230,8 +231,10 @@ export function useFetcher<
     FetchResponse<ResponseData, RequestBody, QueryParams, PathParams>
   >(doSubscribe, getSnapshot, getSnapshot);
 
-  const refetch = useCallback(
-    async (forceRefresh = true) => {
+  const refetch = useCallback<
+    RefetchFunction<ResponseData, RequestBody, QueryParams, PathParams>
+  >(
+    async (forceRefresh = true, requestConfig = {}) => {
       const [currUrl, currConfig, currCacheKey] = currentValuesRef.current;
 
       if (!currUrl) {
@@ -264,6 +267,7 @@ export function useFetcher<
         // Ensure that errors are handled gracefully and not thrown by default
         strategy: 'softFail',
         cacheErrors: true,
+        ...requestConfig,
         _isAutoKey: !currConfig.cacheKey,
       });
     },

--- a/src/types/react-hooks.ts
+++ b/src/types/react-hooks.ts
@@ -7,9 +7,10 @@ import type {
   DefaultResponse,
   FetchResponse,
   MutationSettings,
+  RequestConfig,
 } from './request-handler';
 
-type RefetchFunction<
+export type RefetchFunction<
   ResponseData = DefaultResponse,
   RequestBody = DefaultPayload,
   QueryParams = DefaultParams,
@@ -19,6 +20,12 @@ type RefetchFunction<
   // It comes handy when passing the refetch directly to a click handler.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   forceRefresh?: boolean | any,
+  requestConfig?: RequestConfig<
+    ResponseData,
+    QueryParams,
+    PathParams,
+    RequestBody
+  >,
 ) => Promise<FetchResponse<
   ResponseData,
   RequestBody,

--- a/src/types/request-handler.ts
+++ b/src/types/request-handler.ts
@@ -418,7 +418,7 @@ export interface CacheOptions<
 
   /**
    * INTERNAL, DO NOT USE.
-   * This is used internally to mark requests that are automatically generated cache keys.
+   * This is used internally to mark requests that have cache keys generated automatically.
    */
   _isAutoKey?: boolean;
 


### PR DESCRIPTION
This pull request introduces enhancements to the `useFetcher` hook and related types, allowing more flexible request configurations during refetch operations. It also includes minor documentation updates for internal cache options.

### Enhancements to `useFetcher`:

* [`src/react/index.ts`](diffhunk://#diff-587b8de5cf54d87ca22716308934db0c220fd5f80869c11f3ec096f91fe2bb3dL233-R237): Updated the `refetch` function in `useFetcher` to support an optional `requestConfig` parameter, enabling more granular control over request settings during refetch operations. [[1]](diffhunk://#diff-587b8de5cf54d87ca22716308934db0c220fd5f80869c11f3ec096f91fe2bb3dL233-R237) [[2]](diffhunk://#diff-587b8de5cf54d87ca22716308934db0c220fd5f80869c11f3ec096f91fe2bb3dR270)
* [`src/react/index.ts`](diffhunk://#diff-587b8de5cf54d87ca22716308934db0c220fd5f80869c11f3ec096f91fe2bb3dR20): Imported the `RefetchFunction` type from `src/types/react-hooks` to define the type of the `refetch` function.

### Type updates for `react-hooks`:

* [`src/types/react-hooks.ts`](diffhunk://#diff-730932be9c342b2e83224ccdd61734878704baef89e492b52f66c1b45f9d98b0R10-R13): Exported the `RefetchFunction` type and extended it to include the optional `requestConfig` parameter for specifying request settings during refetch. [[1]](diffhunk://#diff-730932be9c342b2e83224ccdd61734878704baef89e492b52f66c1b45f9d98b0R10-R13) [[2]](diffhunk://#diff-730932be9c342b2e83224ccdd61734878704baef89e492b52f66c1b45f9d98b0R23-R28)

### Documentation improvements:

* [`src/types/request-handler.ts`](diffhunk://#diff-2538f5f783cd3f8001a8caa147e36d87667269b4f75894299a4a46587f344b28L421-R421): Updated the `_isAutoKey` property description to clarify its purpose in marking requests with automatically generated cache keys.